### PR TITLE
Update saml_sessions_controller.rb

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -3,7 +3,7 @@ require "ruby-saml"
 class Devise::SamlSessionsController < Devise::SessionsController
   include DeviseSamlAuthenticatable::SamlConfig
   unloadable if Rails::VERSION::MAJOR < 4
-  skip_before_filter :verify_authenticity_token, raise: false
+  skip_before_action :verify_authenticity_token, raise: false
 
   def new
     idp_entity_id = get_idp_entity_id(params)


### PR DESCRIPTION
Rails 4.2 has deprecated skip_before_filter and suggests an alternative.
 https://guides.rubyonrails.org/4_2_release_notes.html#action-pack-notable-changes
